### PR TITLE
do not log to console if syslog failed

### DIFF
--- a/lib/mcollective/logger/syslog_logger.rb
+++ b/lib/mcollective/logger/syslog_logger.rb
@@ -13,7 +13,7 @@ module MCollective
         level = config.loglevel.to_sym
 
         Syslog.close if Syslog.opened?
-        Syslog.open(File.basename($0), 3, facility)
+        Syslog.open(File.basename($0), LOG_PID, facility)
 
         set_level(level)
       end


### PR DESCRIPTION
See OPSIMP-2402 - here we replacing `LOG_PID | LOG_CONS` with `LOG_PID`